### PR TITLE
correcting grammar in error message

### DIFF
--- a/app/views/beta/report_incident/reportv12/11g_upload_error.html
+++ b/app/views/beta/report_incident/reportv12/11g_upload_error.html
@@ -33,7 +33,7 @@
         href: "#ext"
       },
       {
-        html: "<span class='govuk-visually-hidden'>Error: File name</span>v1 myfile%&.pdf - You cannot add files that use characters that are not letters or numbers in the filename",
+        html: "<span class='govuk-visually-hidden'>Error: File name</span>v1 myfile%&.pdf - You cannot add files with characters other than letters or numbers in the file name",
         href: "#fn"
       }
     ]


### PR DESCRIPTION
"You cannot add files with characters other than letters or numbers in the file name."